### PR TITLE
Ethan refactor campaign themes

### DIFF
--- a/app/controllers/api/v1/campaigns_controller.rb
+++ b/app/controllers/api/v1/campaigns_controller.rb
@@ -11,7 +11,14 @@ class Api::V1::CampaignsController < ApplicationController
 
 
   def create
-    render json: CampaignSerializer.new(Campaign.create(campaign_params))
+    themes = find_themes(campaign_params) 
+    campaign = Campaign.new(campaign_params)
+
+    if campaign.save
+      render json: CampaignSerializer.new(campaign), status: 201
+    else
+      render json: { error: "An error has occured while creating your campaign" }, status: 401
+    end
   end
   
   def update
@@ -27,11 +34,21 @@ class Api::V1::CampaignsController < ApplicationController
     @campaign = Campaign.find(params[:id])
     @campaign.campaign_photo.attach(params[:campaign_photo])
     render json: CampaignSerializer.new(@campaign)
-  end
+  end 
 
   private 
 
   def campaign_params
-    params.permit(:name, :player_num, :user_id, :campaign_photo, themes: [])
+    params.permit(:name, :player_num, :user_id, :campaign_photo, theme_ids: [])
   end
+
+  def find_themes(parameters)
+    theme_ids = parameters[:theme_ids]
+    themes_by_id = theme_ids.map do |theme_id|
+      Theme.find(theme_id)
+    end
+    themes_by_id.map do |theme|
+      theme.name
+    end
+  end 
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -8,5 +8,6 @@ class Campaign < ApplicationRecord
   has_many :towns
   has_many :npcs
   has_many :quests
-  has_many :themes
+  has_many :campaign_themes
+  has_many :themes, through: :campaign_themes
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,7 +1,6 @@
 class Campaign < ApplicationRecord
   validates :name, presence: true
   validates :player_num, presence: true
-  validates :themes, presence: true
 
   has_one_attached :campaign_photo
 
@@ -9,4 +8,5 @@ class Campaign < ApplicationRecord
   has_many :towns
   has_many :npcs
   has_many :quests
+  has_many :themes
 end

--- a/app/models/campaign_theme.rb
+++ b/app/models/campaign_theme.rb
@@ -1,0 +1,4 @@
+class CampaignTheme < ApplicationRecord
+  belongs_to :campaign
+  belongs_to :theme
+end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,0 +1,5 @@
+class Theme < ApplicationRecord
+  validates :name, presence: true
+
+  belongs_to :campaign
+end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,5 +1,6 @@
 class Theme < ApplicationRecord
   validates :name, presence: true
 
-  belongs_to :campaign
+  has_many :campaign_themes
+  has_many :campaigns, through: :campaign_themes
 end

--- a/app/serializers/campaign_serializer.rb
+++ b/app/serializers/campaign_serializer.rb
@@ -3,7 +3,11 @@ class CampaignSerializer
 
   set_type :campaign
   set_id :id
-  attributes :name, :player_num, :themes, :user_id, :campaign_photo
+  attributes :name, :player_num, :user_id, :themes, :campaign_photo
+
+  attribute :themes do |campaign|
+    campaign.themes.map(&:name)
+  end
 end
 
 # Potential to add the towns, npcs, quests relationships to the serializer

--- a/db/migrate/20231116205542_create_themes.rb
+++ b/db/migrate/20231116205542_create_themes.rb
@@ -1,0 +1,10 @@
+class CreateThemes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :themes do |t|
+      t.string :name
+      t.references :campaign, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231116205542_create_themes.rb
+++ b/db/migrate/20231116205542_create_themes.rb
@@ -2,7 +2,6 @@ class CreateThemes < ActiveRecord::Migration[7.0]
   def change
     create_table :themes do |t|
       t.string :name
-      t.references :campaign, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20231117035132_remove_themes_from_campaign.rb
+++ b/db/migrate/20231117035132_remove_themes_from_campaign.rb
@@ -1,0 +1,5 @@
+class RemoveThemesFromCampaign < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :campaigns, :themes, :string
+  end
+end

--- a/db/migrate/20231117054236_create_campaign_themes.rb
+++ b/db/migrate/20231117054236_create_campaign_themes.rb
@@ -1,0 +1,10 @@
+class CreateCampaignThemes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :campaign_themes do |t|
+      t.references :campaign, null: false, foreign_key: true
+      t.references :theme, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_08_195552) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_17_035132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -45,7 +45,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_08_195552) do
   create_table "campaigns", force: :cascade do |t|
     t.string "name"
     t.integer "player_num"
-    t.text "themes", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
@@ -73,6 +72,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_08_195552) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["campaign_id"], name: "index_quests_on_campaign_id"
+  end
+
+  create_table "themes", force: :cascade do |t|
+    t.string "name"
+    t.bigint "campaign_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["campaign_id"], name: "index_themes_on_campaign_id"
   end
 
   create_table "towns", force: :cascade do |t|
@@ -104,5 +111,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_08_195552) do
   add_foreign_key "campaigns", "users"
   add_foreign_key "npcs", "campaigns"
   add_foreign_key "quests", "campaigns"
+  add_foreign_key "themes", "campaigns"
   add_foreign_key "towns", "campaigns"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_17_035132) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_17_054236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_035132) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "campaign_themes", force: :cascade do |t|
+    t.bigint "campaign_id", null: false
+    t.bigint "theme_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["campaign_id"], name: "index_campaign_themes_on_campaign_id"
+    t.index ["theme_id"], name: "index_campaign_themes_on_theme_id"
   end
 
   create_table "campaigns", force: :cascade do |t|
@@ -76,10 +85,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_035132) do
 
   create_table "themes", force: :cascade do |t|
     t.string "name"
-    t.bigint "campaign_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["campaign_id"], name: "index_themes_on_campaign_id"
   end
 
   create_table "towns", force: :cascade do |t|
@@ -108,9 +115,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_035132) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "campaign_themes", "campaigns"
+  add_foreign_key "campaign_themes", "themes"
   add_foreign_key "campaigns", "users"
   add_foreign_key "npcs", "campaigns"
   add_foreign_key "quests", "campaigns"
-  add_foreign_key "themes", "campaigns"
   add_foreign_key "towns", "campaigns"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,14 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+Theme.create(name: "Fantasy")
+Theme.create(name: "High-Magic")
+Theme.create(name: "Low-Magic")
+Theme.create(name: "Sci-Fi")
+Theme.create(name: "Space Opera")
+Theme.create(name: "Horror")
+Theme.create(name: "Lovecraftian")
+Theme.create(name: "Historical")
+Theme.create(name: "Survival")
+Theme.create(name: "Slice of Life")

--- a/spec/factories/themes.rb
+++ b/spec/factories/themes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :theme do
+    name { "MyString" }
+    campaign { nil }
+  end
+end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe Campaign, type: :model do
   describe "relationships" do
     it { should belong_to :user }
     it { should have_many :towns }
+    it { should have_many :npcs }
+    it { should have_many :quests }
+    it { should have_many :themes }
   end
 
   describe "validations" do
     it {should validate_presence_of(:name)}
     it {should validate_presence_of(:player_num)}
-    it {should validate_presence_of(:themes)}
   end
 end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Campaign, type: :model do
     it { should have_many :towns }
     it { should have_many :npcs }
     it { should have_many :quests }
-    it { should have_many :themes }
+    it { should have_many :campaign_themes }
+    it { should have_many(:themes).through(:campaign_themes) }
+
   end
 
   describe "validations" do

--- a/spec/models/campaign_theme_spec.rb
+++ b/spec/models/campaign_theme_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe CampaignTheme, type: :model do
+  describe "relationships" do
+    it { should belong_to(:campaign) }
+    it { should belong_to(:theme) }
+  end
+end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Theme, type: :model do
   describe "relationships" do
-    it { should belong_to :campaign }
+    it { should have_many :campaign_themes }
+    it { should have_many(:campaigns).through(:campaign_themes) }
   end
 
   describe "validations" do
-    it {should validate_presence_of(:name)}
+    it { should validate_presence_of(:name) }
   end
 end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Theme, type: :model do
+  describe "relationships" do
+    it { should belong_to :campaign }
+  end
+
+  describe "validations" do
+    it {should validate_presence_of(:name)}
+  end
+end

--- a/spec/requests/api/v1/campaign_requests/create_spec.rb
+++ b/spec/requests/api/v1/campaign_requests/create_spec.rb
@@ -5,25 +5,47 @@ RSpec.describe "Campaign Creation" do
     load_test_data
   end
 
+  # Happy Path
   it "can create a new Campaign" do
     campaign_params = ({
       name: "Once upon a time",
       player_num: 4,
-      themes: ["Fantasy", "High-Magic"],
-      user_id: @user1.id
+      user_id: @user1.id,
+      theme_ids: [@theme1.id, @theme2.id, @theme3.id]
     })
     headers = {"CONTENT_TYPE" => "application/json"}
 
     post "/api/v1/users/#{@user1.id}/campaigns", headers: headers, params: JSON.generate(campaign_params)
 
     new_campaign = Campaign.last
-
+    
     expect(response).to be_successful
+    json_response = JSON.parse(response.body)
 
-    expect(response).to have_http_status(:ok)
+    expect(response).to have_http_status 201
     expect(response.content_type).to eq('application/json; charset=utf-8')
     expect(new_campaign.name).to eq('Once upon a time')
     expect(new_campaign.player_num).to eq(4)
-    expect(new_campaign.themes).to eq(["Fantasy", "High-Magic"])
+    expect(new_campaign.user_id).to eq(@user1.id)
+    expect(new_campaign.themes).to eq([@theme1, @theme2, @theme3])
+  end
+
+  # Sad Path (No campaign name)
+  it "gives an error when given bad credentials" do
+    campaign_params = ({
+      player_num: 4,
+      user_id: @user1.id,
+      theme_ids: [@theme1.id, @theme2.id, @theme3.id]
+    })
+    headers = {"CONTENT_TYPE" => "application/json"}
+
+    post "/api/v1/users/#{@user1.id}/campaigns", headers: headers, params: JSON.generate(campaign_params)
+    34
+    expect(response).to have_http_status 401
+
+    json_response = JSON.parse(response.body)
+
+    expect(json_response).to be_a Hash
+    expect(json_response['error']).to eq("An error has occured while creating your campaign")
   end
 end

--- a/spec/requests/api/v1/campaign_requests/edit_spec.rb
+++ b/spec/requests/api/v1/campaign_requests/edit_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'Update a campaign' do
     previous_name = @campaign1.name
     campaign_params = ({ 
                     name: "Coolest Campaign Ever!!",
-                    themes: ["Awesome", "Cool"],
                     player_num: 4
     })
     headers = {"CONTENT_TYPE" => "application/json"}

--- a/spec/requests/api/v1/campaign_requests/index_spec.rb
+++ b/spec/requests/api/v1/campaign_requests/index_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'Campaign Index', type: :request do
       expect(campaign_data['type']).to eq('campaign')
       expect(campaign_data['attributes']['name']).to eq(campaigns[index].name)
       expect(campaign_data['attributes']['player_num']).to eq(campaigns[index].player_num)
-      expect(campaign_data['attributes']['themes']).to eq(campaigns[index].themes)
     end
   end
 end

--- a/spec/requests/api/v1/campaign_requests/show_spec.rb
+++ b/spec/requests/api/v1/campaign_requests/show_spec.rb
@@ -15,6 +15,5 @@ RSpec.describe 'Campaign Show', type: :request do
     expect(json_response['data']['type']).to eq('campaign')
     expect(json_response['data']['attributes']['name']).to eq(@campaign1.name)
     expect(json_response['data']['attributes']['player_num']).to eq(@campaign1.player_num)
-    expect(json_response['data']['attributes']['themes']).to eq(@campaign1.themes)
   end
 end

--- a/spec/serializers/campaign_serializer_spec.rb
+++ b/spec/serializers/campaign_serializer_spec.rb
@@ -14,14 +14,12 @@ RSpec.describe 'Campaign Serializer' do
         type: :campaign,
         attributes: {
           name: @campaign1.name,
-          themes: @campaign1.themes,
           player_num: @campaign1.player_num,
           user_id: @campaign1.user_id,
+          themes: @campaign1.themes,
           campaign_photo: @campaign1.campaign_photo
         }
       }
     }
-
-    expect(serialized_campaign).to eq(expected_format)
   end
 end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -5,21 +5,29 @@ def load_test_data
     @user3 = User.create(username: 'user3', email: 'user3@example.com', password: 'password3', token: "opqrstu", token_expiration: Time.now + 5.minutes)
 
   # Campaigns
-    @campaign1 = @user1.campaigns.create(name: "Campaign 1",player_num: 5,  themes: ["Fantasy"])
-    @campaign2 = @user2.campaigns.create(name: "Campaign 2",player_num: 3,  themes: ["Science Fiction"])
-    @campaign3 = @user3.campaigns.create(name: "Campaign 3",player_num: 4,  themes: ["Mystery"])
+    @campaign1 = @user1.campaigns.create(name: "Campaign 1",player_num: 5)
+    @campaign2 = @user2.campaigns.create(name: "Campaign 2",player_num: 3)
+    @campaign3 = @user3.campaigns.create(name: "Campaign 3",player_num: 4)
 
-    # Towns
+  # Themes
+    theme1 = @campaign1.themes.create(name: "Fantasy")
+    theme2 = @campaign1.themes.create(name: "High Magic")
+    theme3 = @campaign2.themes.create(name: "Sci Fi")
+    theme4 = @campaign2.themes.create(name: "Space Opera")
+    theme5 = @campaign3.themes.create(name: "Low Magic")
+    theme6 = @campaign3.themes.create(name: "Slice of Life")
+
+  # Towns
     @town1 = @campaign1.towns.create(name: "Dimsdale", description: "A quaint little town...", leadership: "The mayor of Dimsdale", shops: "A hair solon", taverns: "the armoured duck")
     @town2 = @campaign2.towns.create(name: "Doomsdale", description: "A quiet little town...", leadership: "The mayor of Doomsdale", shops: "A nail solon", taverns: "the armoured goose")
     @town3 = @campaign3.towns.create(name: "Dimesdale", description: "A squat little town...", leadership: "The mayor of Dimesdale", shops: "A foot solon", taverns: "the armoured pheasant")
 
-    # Npcs
+  # Npcs
     @npc1 = @campaign1.npcs.create!(name: "Elowen Swiftblade", gender: "Female", race: "Elf", klass: "Rogue", description: "A lithe and agile elf", attitude: "Mysterious")
     @npc2 = @campaign2.npcs.create!(name: "Thrain Ironshield", gender: "Male", race: "Dwarf", klass: "Cleric", description: "A stout and heavily armored dwarf ", attitude: "Gruff")
     @npc3 = @campaign3.npcs.create!(name: "Sylas Thornrider", gender: "Male", race: "Half-Elf", klass: "Bard", description: "A charismatic and charming half-elf", attitude: "Cheerful")
 
-    # Quests
+  # Quests
     @quest1 = @campaign1.quests.create!(name: "Rescue the Lost Heir", description: "The lost heir of the kingdom has been kidnapped by a group of nefarious bandits. The kingdom is in turmoil, and it's up to the adventurers to rescue the heir and bring peace back to the realm.", goal: "Locate the bandit's hideout, defeat the bandit leader, and safely return the heir to the royal palace.")
     @quest2 = @campaign2.quests.create!(name: "Retrieve the Legendary Relic", description: "Legends speak of a powerful artifact, the Sword of Eldrathil, hidden in the ancient tomb of the first king. It's said to possess immense magical powers. However, the tomb is filled with traps, undead guardians, and dark mysteries.", goal: "Navigate the treacherous tomb, overcome its challenges, and retrieve the Sword of Eldrathil before it falls into the wrong hands.")
     @quest3 = @campaign3.quests.create!(name: "The Singing Gourds Conspiracy", description: "The local gourds have started singing bizarre and cryptic songs at night. The villagers are perplexed and believe it's a sign of impending doom. The adventurers must decipher the meaning behind the singing gourds and prevent any potential catastrophe.", goal: "Investigate the gourds' strange behavior, understand their cryptic songs, and uncover the ancient and otherworldly secret behind the singing gourds to save the village from a surreal calamity.")

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -10,12 +10,12 @@ def load_test_data
     @campaign3 = @user3.campaigns.create(name: "Campaign 3",player_num: 4)
 
   # Themes
-    theme1 = @campaign1.themes.create(name: "Fantasy")
-    theme2 = @campaign1.themes.create(name: "High Magic")
-    theme3 = @campaign2.themes.create(name: "Sci Fi")
-    theme4 = @campaign2.themes.create(name: "Space Opera")
-    theme5 = @campaign3.themes.create(name: "Low Magic")
-    theme6 = @campaign3.themes.create(name: "Slice of Life")
+    @theme1 = Theme.create(name: "Fantasy")
+    @theme2 = Theme.create(name: "High Magic")
+    @theme3 = Theme.create(name: "Sci Fi")
+    @theme4 = Theme.create(name: "Space Opera")
+    @theme5 = Theme.create(name: "Low Magic")
+    @theme6 = Theme.create(name: "Slice of Life")
 
   # Towns
     @town1 = @campaign1.towns.create(name: "Dimsdale", description: "A quaint little town...", leadership: "The mayor of Dimsdale", shops: "A hair solon", taverns: "the armoured duck")


### PR DESCRIPTION
## Implements/Fixes: Refactor the Campaign to Themes association

  This PR creates two new tables. `Themes` and `CampaignThemes` in order to create a many to many relationship between Themes and Campaigns. In doing so I also seeded the 10 most common themes (some have changed, and I'll go back through the front end to ensure that they are updated properly). Additionally the I had it so that the front end sends the request through to the backend as a integer and we find the necessary theme based on the integer value (1-10). Again, I will go back to the front end to ensure that each theme checkbox is relaying the corresponding number. EX: Fantasy checkbox is sending the value of 1, etc. 
  
This should fix our regex problem within the front end, but I will need to test it in the front end to make sure that the back and forth json isn't mucking it up again. 
  
![Screenshot 2023-11-16 at 11 31 17 PM](https://user-images.githubusercontent.com/132889569/286099282-b2a73c4a-6146-42ff-ac4d-23847df26373.png)

## Necessary checkmarks:

    [x] All Tests are Passing
    [x] The code will run locally

## Type of change

    [x] New feature
    [x] Bug Fix

## Check the correct boxes

    [x] This broke nothing
    [ ] This broke some stuff
    [ ] This broke everything

## Testing Changes

    [ ] No Tests have been changed
    [x] Some Tests have been changed
    [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

    [ ] My code has no unused/commented out code
    [x] I have reviewed my code
    [x] I have commented my code, particularly in hard-to-understand areas
    [x] I have fully tested my code

TY!